### PR TITLE
Remove leading white space from class list

### DIFF
--- a/convert/src/file.ts
+++ b/convert/src/file.ts
@@ -22,7 +22,8 @@ class ${twClass} {
 
   // Building methods
   private add(value: string): ${twClass} {
-    this.value = \`\${this.value} \${value}\`;
+    this.value && (this.value += " ");
+    this.value += value;
     return this;
   }
 


### PR DESCRIPTION
Now, every generated string has a leading white space.

We can conditionally add a white space when the string is not empty.